### PR TITLE
1.6.2-40: xspec module supports renaming of models

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -83,6 +83,8 @@ Changes since 1.6.2 (released Jan 2012)
 39.  xspec module: new lmodel keyword for load_xspec_local_models,
      build_xspec_local_models.  Also, update etc/aped.sl to read
      a versioned ionization balance filename.
+40.  xspec module supports xspec_rename_model_hook to rename
+     xspec models provided to isis.
 
 Changes since 1.6.1 (released Jul 2010)
 ---------------------------------------

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -30,7 +30,7 @@ patch_index:
 	sed -e 's/\\begin{theindex}/$(TOC)/' $(DOC).ind > tmp.ind
 	mv -f tmp.ind $(DOC).ind
 
-postscript:	$(DOC).tex
+postscript:	$(DOC).pdf
 	pdftops $(DOC).pdf
 
 old-postscript:	$(DOC).tex

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -14299,7 +14299,7 @@ xspec_config_hook
 
 
  SEE ALSO
-    __set_hard_limits
+    xspec_rename_model_hook, __set_hard_limits
 
 ------------------------------------------------------------------------
 xspec_elabund
@@ -14492,6 +14492,39 @@ xspec_photo
 
  SEE ALSO
     xspec_gphoto
+
+------------------------------------------------------------------------
+xspec_rename_model_hook
+
+ SYNOPSIS
+    Define a mapping from xspec model to ISIS fit-function names
+
+ USAGE
+    xspec_rename_model_hook (isis_model_name_assoc_array)
+
+ DESCRIPTION
+    If a function named `xspec_rename_model_hook' is defined when
+    the XSPEC module is loaded, then that function will be called
+    with an associative array as a parameter. The hook can be used
+    to define different fit-function names for XSPEC models that
+    are provided to ISIS -- e.g., to avoid name clashes with its
+    own intrinsic fit-functions.
+
+    Unlike xspec_config_hook, xspec_rename_model_hook is called
+    before the XSPEC module initializes its fit functions.
+
+    For example, in order to rename XSPEC's voigt model to VOIGT,
+    one can define the following function in the installation's
+    isis/etc/local.sl or even one's personal .isisrc file:
+
+       define xspec_rename_model_hook (isis_model_name)
+       {
+          isis_model_name["voigt"] = "VOIGT";
+       }
+
+
+ SEE ALSO
+    xspec_config_hook
 
 ------------------------------------------------------------------------
 xspec_set_cosmo

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -2971,7 +2971,7 @@ is_flux_mode
      compatibility with earlier versions of ISIS -- it may be
      removed in a subsequent release.
 
-    Use this function to determine whether isis is currently
+    Use this function to determine whether ISIS is currently
     dealing with flux data or count data.  If the return value is
     one, commands such as get_data, put_data and plot_data all
     refer to flux-corrected data (e.g. the FLUX column in the Type

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -15372,7 +15372,7 @@ array of abundance values relative to Hydrogen.
 {xspec\_config\_hook}
 {Perform xspec related customizations}
 {xspec\_config\_hook()}
-{\_\_set\_hard\_limits}
+{xspec\_rename\_model\_hook, \_\_set\_hard\_limits}
 
 \index{XSPEC module!customization}
 \index{xspec\_config\_hook@{\tt xspec\_config\_hook}}
@@ -15555,6 +15555,33 @@ subroutine distributed with xspec.  From the source code:
       photo   r       r: Cross-section in cm**2
 \end{verbatim}
 
+\end{isisfunction}
+
+\begin{isisfunction}
+{xspec\_rename\_model\_hook}
+{Define a mapping from \xspec\ model to \isisx fit-function names}
+{xspec\_rename\_model\_hook (isis\_model\_name\_assoc\_array)}
+{xspec\_config\_hook}
+
+If a function named `\verb|xspec_rename_model_hook|' is defined when
+the \xspec\ module is loaded, then that function will be called
+with an associative array as a parameter. The hook can be used
+to define different fit-function names for \xspec\ models that
+are provided to \isisx -- e.g., to avoid name clashes with its
+own intrinsic fit-functions.
+
+Unlike \verb|xspec_config_hook|, \verb|xspec_rename_model_hook| is called
+before the \xspec\ module initializes its fit functions.
+
+For example, in order to rename \xspec's \verb|voigt| model to \verb|VOIGT|,
+one can define the following function in the installation's
+\verb|isis/etc/local.sl| or even one's personal \verb|.isisrc| file:
+\begin{verbatim}
+   define xspec_rename_model_hook (isis_model_name)
+   {
+      isis_model_name["voigt"] = "VOIGT";
+   }
+\end{verbatim}
 \end{isisfunction}
 
 \begin{isisfunction}

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -4914,7 +4914,7 @@ function is still available primarily to provide compatibility with
 earlier versions of \isisx -- it may be removed in a subsequent
 release.
 
-Use this function to determine whether \isis is currently dealing with
+Use this function to determine whether \isisx is currently dealing with
 flux data or count data.  If the return value is one, commands such as
 {\tt get\_data}, {\tt put\_data} and {\tt plot\_data} all refer to
 {\it flux-corrected} data (e.g. the {\tt FLUX} column in the Type II
@@ -15641,7 +15641,7 @@ making it possible to over-ride site-local definitions from either the
 
 Although the simplest configuration doesn't require setting any
 environment variables, several environment variables are available to
-help customize \isis (Table \ref{env-tbl}).  Note that, because \slang\
+help customize \isisx (Table \ref{env-tbl}).  Note that, because \slang\
 provides the ability to change environment variables of the isis process, it
 is possible to change some of of the following values at run-time
 (it is not useful to change those environment variables which are examined

--- a/src/isis.h
+++ b/src/isis.h
@@ -36,7 +36,7 @@ extern "C" {
 #include <slang.h>
 
 #define ISIS_VERSION          10602
-#define ISIS_VERSION_STRING  "1.6.2-39"
+#define ISIS_VERSION_STRING  "1.6.2-40"
 #define ISIS_VERSION_PREFIX   1.6.2
 
 #define ISIS_API_VERSION 6


### PR DESCRIPTION
A new hook `xspec_rename_model_hook' has been introduced:
If it is defined (before the xspec module is loaded!),
it will be called with an associative array as a parameter,
which can be filled to define different fit-function names
for xspec models that are provided by ISIS' xspec module.

Example:
  In order to rename xspec's fit-function "voigt" to "VOIGT"
  (avoiding to overwrite ISIS' fit-function with that name),
  one can define the following function in the installation's
  isis/etc/local.sl (or even one's personal ~/.isisrc):

        define xspec_rename_model_hook (isis_model_name)
        {
           isis_model_name["voigt"] = "VOIGT";
        }