### PR TITLE
1.6.2-41.td1: gainshift kernel can have negative energy offsets

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -86,6 +86,10 @@ Changes since 1.6.2 (released Jan 2012)
 40.  xspec module supports xspec_rename_model_hook to rename
      xspec models provided to isis.
 41.  Updates to support heasoft-6.23
+41.td1. gainshift kernel can have negative energy offsets as long
+	as the resulting energy grid consists entirely of positive
+	values
+
 
 Changes since 1.6.1 (released Jul 2010)
 ---------------------------------------

--- a/modules/xspec/src/xspec.sl
+++ b/modules/xspec/src/xspec.sl
@@ -843,7 +843,11 @@ private define atable_hook (file, args_ref) %{{{
 define add_atable_model () %{{{
 {
    variable msg = "add_atable_model (file, name);";
-   variable fmt = "define %s_fit(l,h,p){_set_table_model_filename(\"%s\"); variable n = length(p); if (n > 1) return p[0]*_atbl(l,h,p[[1:n-1]]); else return p[0] * _atbl(l,h,NULL);}";
+   variable fmt = "define %s_fit(l,h,p){_set_table_model_filename(\"%s\"); \
+                   variable n = length(p); \
+                   _set_table_model_number_of_parameters(n-1); \
+                   _set_table_model_type(\"add\"); \
+                   if (n > 1) return p[0]*_atbl(l,h,p[[1:n-1]]); else return p[0] * _atbl(l,h,NULL);}";
 
    _add_table_model (_NARGS, msg, fmt, &atable_hook, 1);
 }
@@ -853,7 +857,11 @@ define add_atable_model () %{{{
 define add_mtable_model () %{{{
 {
    variable msg = "add_mtable_model (file, name);";
-   variable fmt = "define %s_fit(l,h,p){_set_table_model_filename(\"%s\");return _mtbl(l,h,p);}";
+   variable fmt = "define %s_fit(l,h,p){_set_table_model_filename(\"%s\"); \
+                   variable n = length(p); \
+                   _set_table_model_number_of_parameters(n); \
+                   _set_table_model_type(\"mul\"); \
+                   return _mtbl(l,h,p);}";
 
    _add_table_model (_NARGS, msg, fmt, &redshift_hook, 0);
 }

--- a/src/isis.h
+++ b/src/isis.h
@@ -36,7 +36,7 @@ extern "C" {
 #include <slang.h>
 
 #define ISIS_VERSION          10602
-#define ISIS_VERSION_STRING  "1.6.2-41"
+#define ISIS_VERSION_STRING  "1.6.2-41.td1"
 #define ISIS_VERSION_PREFIX   1.6.2
 
 #define ISIS_API_VERSION 6

--- a/src/isis.h
+++ b/src/isis.h
@@ -36,7 +36,7 @@ extern "C" {
 #include <slang.h>
 
 #define ISIS_VERSION          10602
-#define ISIS_VERSION_STRING  "1.6.2-41.td1"
+#define ISIS_VERSION_STRING  "1.6.2-41.td2"
 #define ISIS_VERSION_PREFIX   1.6.2
 
 #define ISIS_API_VERSION 6

--- a/src/std_kernel.c
+++ b/src/std_kernel.c
@@ -478,7 +478,7 @@ static int compute_gainshift_kernel (Isis_Kernel_t *k, double *result, Isis_Hist
    if (-1 == compute_kernel (k, result, g, par, num, fun))
      return -1;
 
-   if ((par[0] < 0) || (par[1] == 0.0))
+   if (par[1] == 0.0)
      {
         isis_vmesg(FAIL, I_ERROR, __FILE__, __LINE__,
                    "gainshift kernel:  parameters (%g, %g) define an invalid grid",
@@ -498,6 +498,18 @@ static int compute_gainshift_kernel (Isis_Kernel_t *k, double *result, Isis_Hist
 #define NEW_LAMBDA(y)    (1.0/(1.0/y/slope - r0))
 
    shift_lo[0] = NEW_LAMBDA(ylo[0]);
+
+   if (shift_lo[0]<0.)
+     {
+        isis_vmesg(FAIL, I_ERROR, __FILE__, __LINE__,
+                   "gainshift kernel:  parameters (%g, %g) define a grid with negative energies",
+                   par[0], par[1]);
+	ISIS_FREE(tmp);
+	
+	return -1;
+     }
+
+   
    for (i = 1; i < n; i++)
      {
         shift_lo[i] = NEW_LAMBDA(ylo[i]);


### PR DESCRIPTION
    The existing implementation of the gainshift model assumes that all
    response matrices start at 0keV and therefore do not allow a negative
    shift in energy. In reality this is not true. This commit modifies the
    gainshift kernel to allow negative energy offsets as long as the
    resulting energy grid consists entirely of positive values.