### PR TITLE
 Fix wildcard patterns  & png library configuration

### DIFF
--- a/configure
+++ b/configure
@@ -8195,10 +8195,10 @@ then
   OTHER_PGPLOT_LIBS=""
   if test -f "$jh_pgplot_libfile" ; then
     case "$jh_pgplot_libfile" in
-       "*.so" )
+       *".so" )
          jh_png_symbols=`ldd $jh_pgplot_libfile | grep -i png`
          ;;
-       "*.a" )
+       *".a" )
          jh_png_symbols=`nm $jh_pgplot_libfile | grep -i png`
          ;;
      esac
@@ -8373,10 +8373,10 @@ else
   OTHER_PGPLOT_LIBS=""
   if test -f "$jh_pgplot_libfile" ; then
     case "$jh_pgplot_libfile" in
-       "*.so" )
+       *".so" )
          jh_png_symbols=`ldd $jh_pgplot_libfile | grep -i png`
          ;;
-       "*.a" )
+       *".a" )
          jh_png_symbols=`nm $jh_pgplot_libfile | grep -i png`
          ;;
      esac
@@ -9126,10 +9126,10 @@ $as_echo "no" >&6; }
   OTHER_PGPLOT_LIBS=""
   if test -f "$jh_pgplot_libfile" ; then
     case "$jh_pgplot_libfile" in
-       "*.so" )
+       *".so" )
          jh_png_symbols=`ldd $jh_pgplot_libfile | grep -i png`
          ;;
-       "*.a" )
+       *".a" )
          jh_png_symbols=`nm $jh_pgplot_libfile | grep -i png`
          ;;
      esac

--- a/configure
+++ b/configure
@@ -8196,7 +8196,7 @@ then
   if test -f "$jh_pgplot_libfile" ; then
     case "$jh_pgplot_libfile" in
        *".so" )
-         jh_png_symbols=`ldd $jh_pgplot_libfile | grep -i png`
+         jh_png_symbols=`objdump -pt $jh_pgplot_libfile | grep -i png`
          ;;
        *".a" )
          jh_png_symbols=`nm $jh_pgplot_libfile | grep -i png`
@@ -8374,7 +8374,7 @@ else
   if test -f "$jh_pgplot_libfile" ; then
     case "$jh_pgplot_libfile" in
        *".so" )
-         jh_png_symbols=`ldd $jh_pgplot_libfile | grep -i png`
+         jh_png_symbols=`objdump -pt $jh_pgplot_libfile | grep -i png`
          ;;
        *".a" )
          jh_png_symbols=`nm $jh_pgplot_libfile | grep -i png`
@@ -9127,7 +9127,7 @@ $as_echo "no" >&6; }
   if test -f "$jh_pgplot_libfile" ; then
     case "$jh_pgplot_libfile" in
        *".so" )
-         jh_png_symbols=`ldd $jh_pgplot_libfile | grep -i png`
+         jh_png_symbols=`objdump -pt $jh_pgplot_libfile | grep -i png`
          ;;
        *".a" )
          jh_png_symbols=`nm $jh_pgplot_libfile | grep -i png`


### PR DESCRIPTION
Fix wildcard patterns.
In Linux, shared library (libpgplot.so) which is built by default since heasoft 6.22 is not linked to the png library, actually is static, ldd doesn't work.