### PR TITLE
1.6.2-43.td1 Implements complex type as columns in the cfitsio module

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -92,6 +92,7 @@ Changes since 1.6.2 (released Jan 2012)
 41.td2. update xspec module tabint interface
 42.  Updates to support heasoft-6.25
 43.  Rewrite configure script logic to manage linking libpng for pgplot
+43.td1 Implements complex type as columns in the cfitsio module
 
 Changes since 1.6.1 (released Jul 2010)
 ---------------------------------------

--- a/modules/cfitsio/src/cfitsio-module.c
+++ b/modules/cfitsio/src/cfitsio-module.c
@@ -178,6 +178,11 @@ static int map_fitsio_type_to_slang (int *typep, long *repeat, SLtype *stype)
 	*stype = SLANG_STRING_TYPE;
 	break;
 
+      case TCOMPLEX:
+      case TDBLCOMPLEX:
+        *stype = SLANG_COMPLEX_TYPE;
+        break;
+
       default:
 	SLang_verror (SL_NOT_IMPLEMENTED, "Fits column type %d is not supported",
 		      type);
@@ -1551,6 +1556,10 @@ static int write_col (FitsFile_Type *ft, int *colnum,
       case SLANG_UCHAR_TYPE:
 	type = TBYTE;
 	break;
+
+      case SLANG_COMPLEX_TYPE:
+        type = TDBLCOMPLEX;
+        break;
 
       default:
 	SLang_verror (SL_NOT_IMPLEMENTED,

--- a/modules/cfitsio/src/fits.sl
+++ b/modules/cfitsio/src/fits.sl
@@ -1468,6 +1468,9 @@ define fits_write_binary_table ()
 	  {
 	   case Int64_Type: t = "K";
 	  }
+          {
+           case Complex_Type: t = "M";
+          }
 	  {
 	     verror ("%s: %s column: %S type not supported", _function_name, colname, t);
 	  }


### PR DESCRIPTION
We found out that the current implementation of the cfitsio module does not allow for a Complex Type as a column in a FITS extension. We added this functionality in this commit. Cheers, Thomas